### PR TITLE
chore: switch to fork of `chartjs-plugin-streaming`

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ A curated list of awesome things related to [Chart.js](https://www.chartjs.org)
   Support | Name | Description
   -- | -- | --
   2️⃣ 3️⃣ 4️⃣ | [datasource-prometheus](https://github.com/samber/chartjs-plugin-datasource-prometheus) | Displays time-series from Prometheus
-  2️⃣ 3️⃣ ❕ | [streaming](https://github.com/nagix/chartjs-plugin-streaming) | Adds support for live streaming data
+  2️⃣ 3️⃣ 4️⃣ | [streaming](https://github.com/Robloche/chartjs-plugin-streaming) | Adds support for live streaming data
 
 In addition, many plugins can be found on the [npm registry](https://www.npmjs.com/search?q=chartjs-plugin-).
 


### PR DESCRIPTION
Awesome Contribution Checklist:

<!-- *** If you do not abide by the Contributing Guidelines, your Pull Request WILL BE CLOSED -->

- [x] I have read, and re-read the [Contributing Guidelines](https://github.com/chartjs/awesome/blob/master/CONTRIBUTING.md)
- [x] I have searched to ensure the suggested item doesn't exist on this list
- [x] This PR contains only one item

### Please Describe Your Addition

switched out the original streaming plugin from `nagix` with a fork from `Robloche`, as this adds support for Chart.js `4.x`.